### PR TITLE
Update README.adoc 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -308,7 +308,7 @@ Open Liberty Docker image:
 
 [role='command']
 ```
-docker pull openliberty/open-liberty:full-java8-openj9-ubi
+docker pull openliberty/open-liberty:full-java11-openj9-ubi
 ```
 
 Run the following commands to containerize the `frontend`, `bff`, and `system` services:


### PR DESCRIPTION
pull openliberty/open-liberty:full-java11-openj9-ubi instead of java8